### PR TITLE
Update DirectVmTest.java

### DIFF
--- a/camel-cookbook-structuring-routes/src/test/java/org/camelcookbook/structuringroutes/vm/DirectVmTest.java
+++ b/camel-cookbook-structuring-routes/src/test/java/org/camelcookbook/structuringroutes/vm/DirectVmTest.java
@@ -45,14 +45,14 @@ public class DirectVmTest {
             public void configure() throws Exception {
                 from("direct:in")
                     .setHeader("harness.threadName", simple("${threadName}"))
-                    .to("vm:logMessageToBackendSystem")
+                    .to("direct-vm:logMessageToBackendSystem")
                     .log("Completed logging");
             }
         });
         testHarnessContext.start();
 
         externalLoggingContext = new DefaultCamelContext();
-        externalLoggingContext.addRoutes(new ExternalLoggingRouteBuilder("vm"));
+        externalLoggingContext.addRoutes(new ExternalLoggingRouteBuilder("direct-vm"));
         externalLoggingContext.start();
     }
 
@@ -73,7 +73,7 @@ public class DirectVmTest {
         producerTemplate.sendBody("direct:in", "something happened");
         out.assertIsSatisfied(1000);
         Message message = out.getExchanges().get(0).getIn();
-        assertFalse(message.getHeader("harness.threadName").equals(
+        assertTrue(message.getHeader("harness.threadName").equals(
             message.getHeader(ExternalLoggingRouteBuilder.LOGGING_THREAD_NAME)));
     }
 }


### PR DESCRIPTION
I was only able to get the test to run after making some changes to the camel routes and the final test assertion. The current setup is accurate when using the `vm` component, but for `direct-vm` we should expect the routes to all run in the same thread.